### PR TITLE
rename: head index -> snapshot index

### DIFF
--- a/lol-core/src/core_message.rs
+++ b/lol-core/src/core_message.rs
@@ -19,7 +19,7 @@ pub enum Rep {
         membership: Vec<Id>,
     },
     LogInfo {
-        head_log_index: u64,
+        snapshot_index: u64,
         last_applied: u64,
         commit_index: u64,
         last_log_index: u64,

--- a/lol-core/src/thread/compaction_l1.rs
+++ b/lol-core/src/thread/compaction_l1.rs
@@ -21,11 +21,11 @@ impl<A: RaftApp> Thread<A> {
             let core = Arc::clone(&self.core);
             let f = async move {
                 log::info!("start compaction L1");
-                let new_head_index = core.log.find_compaction_point(delay).await;
-                log::info!("new compaction point: {:?}", new_head_index);
-                if let Some(new_head_index) = new_head_index {
+                let new_snapshot_index = core.log.find_compaction_point(delay).await;
+                log::info!("new compaction point: {:?}", new_snapshot_index);
+                if let Some(new_snapshot_index) = new_snapshot_index {
                     core.log
-                        .advance_head_log_index(new_head_index, Arc::clone(&core))
+                        .advance_snapshot_index(new_snapshot_index, Arc::clone(&core))
                         .await;
                 }
             };

--- a/lol-core/src/thread/compaction_l2.rs
+++ b/lol-core/src/thread/compaction_l2.rs
@@ -20,9 +20,9 @@ impl<A: RaftApp> Thread<A> {
                 let usage = used_memory_kb / total_memory_kb;
                 if usage > core.tunable.read().await.compaction_memory_limit {
                     log::warn!("start compaction L2");
-                    let new_head_index = core.log.last_applied.load(Ordering::SeqCst);
+                    let new_snapshot_index = core.log.last_applied.load(Ordering::SeqCst);
                     core.log
-                        .advance_head_log_index(new_head_index, Arc::clone(&core))
+                        .advance_snapshot_index(new_snapshot_index, Arc::clone(&core))
                         .await;
                 }
             };

--- a/lol-monitor/src/app.rs
+++ b/lol-monitor/src/app.rs
@@ -11,7 +11,7 @@ pub struct Membership {
 
 #[derive(Clone, Debug)]
 pub struct LogInfo {
-    pub head_log_index: u64,
+    pub snapshot_index: u64,
     pub last_applied: u64,
     pub commit_index: u64,
     pub last_log_index: u64,
@@ -66,7 +66,7 @@ where
             let id = membership.membership[i].to_owned();
             let alive = health_checks.contains(&id);
             let loginfo = loginfos.get(&id).unwrap_or(&LogInfo {
-                head_log_index: 0,
+                snapshot_index: 0,
                 last_applied: 0,
                 commit_index: 0,
                 last_log_index: 0,
@@ -74,7 +74,7 @@ where
             members.push(ui::Member {
                 id: id,
                 alive,
-                head_log_index: loginfo.head_log_index,
+                snapshot_index: loginfo.snapshot_index,
                 last_applied: loginfo.last_applied,
                 commit_index: loginfo.commit_index,
             })

--- a/lol-monitor/src/main.rs
+++ b/lol-monitor/src/main.rs
@@ -103,14 +103,14 @@ async fn main() -> anyhow::Result<()> {
             let res = conn.request_locally(req).await?.into_inner();
             let msg = core_message::Rep::deserialize(&res.message).unwrap();
             if let core_message::Rep::LogInfo {
-                head_log_index,
+                snapshot_index,
                 last_applied,
                 commit_index,
                 last_log_index,
             } = msg
             {
                 Ok(app::LogInfo {
-                    head_log_index,
+                    snapshot_index,
                     last_applied,
                     commit_index,
                     last_log_index,

--- a/lol-monitor/src/ui/mod.rs
+++ b/lol-monitor/src/ui/mod.rs
@@ -14,7 +14,7 @@ use tui::{
 pub struct Member {
     pub id: String,
     pub alive: bool,
-    pub head_log_index: u64,
+    pub snapshot_index: u64,
     pub last_applied: u64,
     pub commit_index: u64,
 }
@@ -73,7 +73,7 @@ where
 
         let snapshot_index = Paragraph::new(Span::raw(format!(
             "Snapshot Index: {}",
-            member.head_log_index
+            member.snapshot_index
         )));
         f.render_widget(snapshot_index, chunks[0]);
 


### PR DESCRIPTION
the name `head` is ambiguous because it may point to the physical head index of the log in the stale area.