### PR TITLE
Rocks bench

### DIFF
--- a/integration/benches/bench.rs
+++ b/integration/benches/bench.rs
@@ -130,9 +130,9 @@ fn bench_query_64(b: &mut test::Bencher) {
     do_bench_query(64, b);
 }
 
-fn do_bench_commit_huge(n: u8, b: &mut test::Bencher) {
+fn do_bench_commit_huge(n: u8, command: impl Fn(u8) -> NodeCommand, b: &mut test::Bencher) {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
-    let env = init_cluster(n);
+    let env = make_cluster(n, command);
     let id = env.get_node_id(0);
     // 100KB
     let mut v = String::new();
@@ -157,19 +157,42 @@ fn do_bench_commit_huge(n: u8, b: &mut test::Bencher) {
         assert!(r.is_ok());
     })
 }
-#[bench]
-fn test_commit_huge_1(b: &mut test::Bencher) {
-    do_bench_commit_huge(1, b)
+fn command_mem(i: u8) -> NodeCommand {
+    NodeCommand::new("kvs-server")
+}
+fn command_rocks(i: u8) -> NodeCommand {
+    let s = format!("--use-persistency={}", i);
+    NodeCommand::new("kvs-server").with_args(vec![s.as_str(), "--reset-persistency"])
 }
 #[bench]
-fn test_commit_huge_4(b: &mut test::Bencher) {
-    do_bench_commit_huge(4, b)
+fn test_commit_huge_1_mem(b: &mut test::Bencher) {
+    do_bench_commit_huge(1, command_mem, b)
 }
 #[bench]
-fn test_commit_huge_16(b: &mut test::Bencher) {
-    do_bench_commit_huge(16, b)
+fn test_commit_huge_4_mem(b: &mut test::Bencher) {
+    do_bench_commit_huge(4, command_mem, b)
 }
 #[bench]
-fn test_commit_huge_64(b: &mut test::Bencher) {
-    do_bench_commit_huge(64, b)
+fn test_commit_huge_16_mem(b: &mut test::Bencher) {
+    do_bench_commit_huge(16, command_mem, b)
+}
+#[bench]
+fn test_commit_huge_64_mem(b: &mut test::Bencher) {
+    do_bench_commit_huge(64, command_mem, b)
+}
+#[bench]
+fn test_commit_huge_1_rocks(b: &mut test::Bencher) {
+    do_bench_commit_huge(1, command_rocks, b)
+}
+#[bench]
+fn test_commit_huge_4_rocks(b: &mut test::Bencher) {
+    do_bench_commit_huge(4, command_rocks, b)
+}
+#[bench]
+fn test_commit_huge_16_rocks(b: &mut test::Bencher) {
+    do_bench_commit_huge(16, command_rocks, b)
+}
+#[bench]
+fn test_commit_huge_64_rocks(b: &mut test::Bencher) {
+    do_bench_commit_huge(64, command_rocks, b)
 }

--- a/integration/src/lib.rs
+++ b/integration/src/lib.rs
@@ -85,5 +85,5 @@ impl Client {
     }
 }
 pub fn init_cluster(n: u8) -> EnvRef {
-    make_cluster(n, kvs_server(vec![]))
+    make_cluster(n, |_| kvs_server(vec![]))
 }

--- a/lol-test/src/lib.rs
+++ b/lol-test/src/lib.rs
@@ -354,10 +354,10 @@ pub fn eventually<T: Eq>(timeout: Duration, should_be: T, f: impl Fn() -> T) -> 
     }
 }
 /// make a cluster with the same command.
-pub fn make_cluster(n: u8, command: NodeCommand) -> EnvRef {
-    let env = Environment::new(0, command.clone());
+pub fn make_cluster(n: u8, command: impl Fn(u8) -> NodeCommand) -> EnvRef {
+    let env = Environment::new(0, command(0).clone());
     for k in 1..n {
-        env.start(k, command.clone());
+        env.start(k, command(k).clone());
         Admin::to(0, env.clone()).add_server(k);
         let mut nodes = vec![];
         for i in 0..=k {


### PR DESCRIPTION
test test_commit_huge_1_mem    ... bench: 101,189,850 ns/iter (+/- 574,935)
test test_commit_huge_1_rocks  ... bench: 101,523,600 ns/iter (+/- 697,163)
test test_commit_huge_4_mem    ... bench:   2,601,324 ns/iter (+/- 825,290)
test test_commit_huge_4_rocks  ... bench:   3,557,303 ns/iter (+/- 1,468,594)
test test_commit_huge_16_mem   ... bench:   5,725,092 ns/iter (+/- 1,992,803)
test test_commit_huge_16_rocks ... bench:   7,028,855 ns/iter (+/- 4,908,362)
test test_commit_huge_64_mem   ... bench:  21,430,683 ns/iter (+/- 7,428,737)
test test_commit_huge_64_rocks ... bench:  28,990,858 ns/iter (+/- 6,872,966)