### PR TITLE
optimize replication (eliminate ArrayEntryBuffer)

### DIFF
--- a/lol-core/Cargo.toml
+++ b/lol-core/Cargo.toml
@@ -18,6 +18,7 @@ prost = "0.6"
 tokio = { version = "0.2", features = ["macros", "fs"] }
 rand = "0.7"
 async-trait = "0.1"
+async-stream = "0.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
@@ -27,6 +28,7 @@ log = "0.4"
 anyhow = "1.0"
 tokio-util = { version = "0.3", features = ["codec"] }
 bytes = "0.5.6"
+sync_wrapper = "0.1"
 
 rocksdb = { version = "0.15", optional = true }
 

--- a/lol-core/src/snapshot.rs
+++ b/lol-core/src/snapshot.rs
@@ -57,10 +57,10 @@ use bytes::Bytes;
 /// the length of each bytes may vary.
 pub type SnapshotStream = std::pin::Pin<Box<dyn futures::stream::Stream<Item = anyhow::Result<Bytes>> + Send + Sync>>;
 pub(crate) type SnapshotStreamOut = std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<GetSnapshotRep, tonic::Status>> + Send + Sync>>;
-pub(crate) fn map_out(st: SnapshotStream) ->  SnapshotStreamOut {
+pub(crate) fn into_out_stream(st: SnapshotStream) ->  SnapshotStreamOut {
     Box::pin(st.map(|res| res.map(|x| GetSnapshotRep { chunk: x.to_vec() }).map_err(|_| tonic::Status::unknown("streaming error"))))
 }
-pub(crate) fn map_in(st: impl Stream<Item = Result<GetSnapshotRep, tonic::Status>>) -> impl Stream<Item = anyhow::Result<Bytes>> {
+pub(crate) fn into_in_stream(st: impl Stream<Item = Result<GetSnapshotRep, tonic::Status>>) -> impl Stream<Item = anyhow::Result<Bytes>> {
     st.map(|res| res.map(|x| x.chunk.into()).map_err(|_| anyhow::Error::msg("streaming error")))
 }
 /// basic snapshot type which is just a byte sequence.


### PR DESCRIPTION
```
test bench_apply_1             ... bench: 101,149,196 ns/iter (+/- 652,848)
test bench_apply_16            ... bench:   2,678,458 ns/iter (+/- 462,677)
test bench_apply_4             ... bench:   1,476,530 ns/iter (+/- 371,923)
test bench_apply_64            ... bench:  10,406,150 ns/iter (+/- 3,504,094)
test bench_commit_1            ... bench: 101,181,125 ns/iter (+/- 663,898)
test bench_commit_16           ... bench:   2,749,949 ns/iter (+/- 545,734)
test bench_commit_4            ... bench:   1,396,401 ns/iter (+/- 518,522)
test bench_commit_64           ... bench:  10,541,175 ns/iter (+/- 3,864,175)
test bench_query_1             ... bench:     543,109 ns/iter (+/- 350,937)
test bench_query_16            ... bench:     567,319 ns/iter (+/- 266,295)
test bench_query_4             ... bench:     527,484 ns/iter (+/- 224,848)
test bench_query_64            ... bench:     620,291 ns/iter (+/- 431,924)
test test_commit_huge_16_mem   ... bench:   5,424,252 ns/iter (+/- 2,026,191)
test test_commit_huge_16_rocks ... bench:   7,151,830 ns/iter (+/- 3,726,307)
test test_commit_huge_1_mem    ... bench: 101,225,251 ns/iter (+/- 590,917)
test test_commit_huge_1_rocks  ... bench: 101,557,093 ns/iter (+/- 693,465)
test test_commit_huge_4_mem    ... bench:   2,362,714 ns/iter (+/- 680,366)
test test_commit_huge_4_rocks  ... bench:   3,390,545 ns/iter (+/- 1,655,397)
test test_commit_huge_64_mem   ... bench:  20,304,060 ns/iter (+/- 6,745,655)
test test_commit_huge_64_rocks ... bench:  27,272,589 ns/iter (+/- 19,271,983)
```