### PR TITLE
fix: replace HashMap with BTreeMap in fold snapshot

### DIFF
--- a/lol-core/src/lib.rs
+++ b/lol-core/src/lib.rs
@@ -4,7 +4,7 @@
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use std::collections::{HashMap, BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -1274,7 +1274,7 @@ impl Log {
         {
             let mut base_snapshot_index = cur_snapshot_index; 
             let mut new_membership = membership;
-            let mut commands = HashMap::new();
+            let mut commands = BTreeMap::new();
             for i in cur_snapshot_index + 1..=new_snapshot_index {
                 let command = self.storage.get_entry(i).await?.unwrap().command;
                 commands.insert(i, command);


### PR DESCRIPTION
unfortunately, the log entrires are passed to RaftApp in random order
because the HashMap doesn't preserve the key order.

NOTE: very lucky to find this. when I was looking into the log for a different issue I happened to find this.