### PR TITLE
Use Bytes as AppendStreamEntry.command for zero-copy

### DIFF
--- a/lol-core/build.rs
+++ b/lol-core/build.rs
@@ -6,7 +6,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     .out_dir(OUT_DIR)
     //     .compile(&["proto/lol-core.proto"], &["proto"])?;
 
-    let config = prost_build::Config::new();
+    let mut config = prost_build::Config::new();
+    config.bytes(&[".lol_core.AppendStreamEntry.command"]);
     tonic_build::configure()
         .compile_with_config(config, &["proto/lol-core.proto"], &["proto"])?;
 

--- a/lol-core/src/lib.rs
+++ b/lol-core/src/lib.rs
@@ -414,7 +414,7 @@ fn into_out_stream(
         Elem::Entry(AppendStreamEntry {
             term: e.term,
             index: e.index,
-            command: e.command.as_ref().into(),
+            command: e.command,
         })
     });
     header_stream.chain(chunk_stream).map(|e| crate::proto_compiled::AppendEntryReq {

--- a/lol-core/src/server.rs
+++ b/lol-core/src/server.rs
@@ -39,7 +39,7 @@ async fn into_in_stream(mut out_stream: tonic::Streaming<AppendEntryReq>) -> cra
                     let e = crate::LogStreamElem {
                         term,
                         index,
-                        command: command.into(),
+                        command: command,
                     };
                     yield e;
                 },


### PR DESCRIPTION
This reduces copy between Entry's Bytes and StreamEntry's Bytes.