### PR TITLE
fix: error handling in try_insert_entry

### DIFF
--- a/lol-core/src/lib.rs
+++ b/lol-core/src/lib.rs
@@ -1168,19 +1168,18 @@ impl Log {
                     snapshot_index
                 );
 
+                // Snapshot resource is not defined with snapshot_index=1.
                 if sender_id != core.id && snapshot_index > 1 {
-                    let res = core.fetch_snapshot(snapshot_index, sender_id.clone()).await;
-                    if res.is_err() {
-                        log::error!(
-                            "could not fetch app snapshot (idx={}) from sender {}",
-                            snapshot_index,
-                            sender_id
-                        );
-                        return Ok(TryInsertResult::Rejected);
+                    if let Err(e) = core.fetch_snapshot(snapshot_index, sender_id.clone()).await {
+                        log::error!("could not fetch app snapshot (idx={}) from sender {}", snapshot_index, sender_id);
+                        return Err(e);
                     }
                 }
+                if let Err(e) = self.insert_snapshot(entry).await {
+                    log::error!("could not insert snapshot entry (idx={})", snapshot_index);
+                    return Err(e);
+                }
 
-                self.insert_snapshot(entry).await?;
                 self.commit_index
                     .store(snapshot_index - 1, Ordering::SeqCst);
                 self.last_applied


### PR DESCRIPTION
try_insert_entry shouldn't return Rejected.
Doing so, leader moves replication cursor backward but this isn't
the expected behavior.