### PR TITLE
Implement Tune message

### DIFF
--- a/lol-admin/src/main.rs
+++ b/lol-admin/src/main.rs
@@ -27,6 +27,8 @@ enum Sub {
     ClusterInfo,
     #[structopt(name = "timeout-now")]
     TimeoutNow,
+    #[structopt(name = "tunable-config")]
+    TunableConfigInfo
 }
 #[tokio::main]
 async fn main() {
@@ -74,6 +76,20 @@ async fn main() {
         Sub::TimeoutNow => {
             let req = proto_compiled::TimeoutNowReq {};
             conn.timeout_now(req).await.unwrap();
+        }
+        Sub::TunableConfigInfo => {
+            let msg = core_message::Req::TuneConfigInfo;
+            let req = proto_compiled::ProcessReq {
+                message: core_message::Req::serialize(&msg),
+                core: true,
+            };
+            let res = conn
+                .request_process_locally(req)
+                .await
+                .unwrap()
+                .into_inner();
+            let msg = core_message::Rep::deserialize(&res.message).unwrap();
+            println!("TunableConfig response : {}", serde_json::to_string(&msg).unwrap())
         }
     }
 }

--- a/lol-admin/src/main.rs
+++ b/lol-admin/src/main.rs
@@ -78,7 +78,7 @@ async fn main() {
             conn.timeout_now(req).await.unwrap();
         }
         Sub::TunableConfigInfo => {
-            let msg = core_message::Req::TuneConfigInfo;
+            let msg = core_message::Req::TunableConfigInfo;
             let req = proto_compiled::ProcessReq {
                 message: core_message::Req::serialize(&msg),
                 core: true,

--- a/lol-core/build.rs
+++ b/lol-core/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut config = prost_build::Config::new();
     config.bytes(&[".lol_core.AppendStreamEntry.command"]);
+    config.protoc_arg("--experimental_allow_proto3_optional");
     tonic_build::configure().compile_with_config(config, &["proto/lol-core.proto"], &["proto"])?;
 
     Ok(())

--- a/lol-core/proto/lol-core.proto
+++ b/lol-core/proto/lol-core.proto
@@ -81,6 +81,13 @@ message RemoveServerReq {
 }
 message RemoveServerRep {}
 
+message TunableConfigReq {
+    uint64 compaction_delay_sec = 1;
+    uint64 compaction_interval_sec = 2;
+}
+
+message TunableConfigRep {}
+
 service Raft {
     rpc RequestVote (RequestVoteReq) returns (RequestVoteRep);
     rpc SendAppendEntry (stream AppendEntryReq) returns (AppendEntryRep);
@@ -93,4 +100,5 @@ service Raft {
     rpc TimeoutNow (TimeoutNowReq) returns (TimeoutNowRep);
     rpc AddServer (AddServerReq) returns (AddServerRep);
     rpc RemoveServer (RemoveServerReq) returns (RemoveServerRep);
+    rpc TuneConfig (TunableConfigReq) returns (TunableConfigRep);
 }

--- a/lol-core/proto/lol-core.proto
+++ b/lol-core/proto/lol-core.proto
@@ -82,8 +82,8 @@ message RemoveServerReq {
 message RemoveServerRep {}
 
 message TunableConfigReq {
-    uint64 compaction_delay_sec = 1;
-    uint64 compaction_interval_sec = 2;
+    optional uint64 compaction_delay_sec = 1;
+    optional uint64 compaction_interval_sec = 2;
 }
 
 message TunableConfigRep {}
@@ -100,5 +100,5 @@ service Raft {
     rpc TimeoutNow (TimeoutNowReq) returns (TimeoutNowRep);
     rpc AddServer (AddServerReq) returns (AddServerRep);
     rpc RemoveServer (RemoveServerReq) returns (RemoveServerRep);
-    rpc TuneConfig (TunableConfigReq) returns (TunableConfigRep);
+    rpc TunableConfig (TunableConfigReq) returns (TunableConfigRep);
 }

--- a/lol-core/src/core_message.rs
+++ b/lol-core/src/core_message.rs
@@ -8,6 +8,7 @@ pub enum Req {
     ClusterInfo,
     LogInfo,
     HealthCheck,
+    TuneConfigInfo,
 }
 /// Reply
 #[derive(serde::Serialize, serde::Deserialize, std::fmt::Debug)]
@@ -25,7 +26,10 @@ pub enum Rep {
     HealthCheck {
         ok: bool,
     },
-    // TODO: Tune
+    TuneConfigInfo {
+        compaction_delay_sec: u64,
+        compaction_interval_sec: u64,
+    }
 }
 impl Req {
     pub fn serialize(x: &Self) -> Vec<u8> {

--- a/lol-core/src/core_message.rs
+++ b/lol-core/src/core_message.rs
@@ -8,7 +8,7 @@ pub enum Req {
     ClusterInfo,
     LogInfo,
     HealthCheck,
-    TuneConfigInfo,
+    TunableConfigInfo,
 }
 /// Reply
 #[derive(serde::Serialize, serde::Deserialize, std::fmt::Debug)]
@@ -26,7 +26,7 @@ pub enum Rep {
     HealthCheck {
         ok: bool,
     },
-    TuneConfigInfo {
+    TunableConfigInfo {
         compaction_delay_sec: u64,
         compaction_interval_sec: u64,
     }

--- a/lol-core/src/lib.rs
+++ b/lol-core/src/lib.rs
@@ -348,6 +348,20 @@ impl<A: RaftApp> RaftCore<A> {
                 let res = core_message::Rep::HealthCheck { ok: true };
                 Ok(core_message::Rep::serialize(&res))
             }
+            core_message::Req::TuneConfigInfo => {
+                match self.tunable.try_read() {
+                    Ok(tunable) => {
+                        let res = core_message::Rep::TuneConfigInfo {
+                            compaction_delay_sec: tunable.compaction_delay_sec,
+                            compaction_interval_sec: tunable.compaction_interval_sec,
+                        };
+                        Ok(core_message::Rep::serialize(&res))
+                    },
+                    Err(_) => {
+                        Err(anyhow!("cannot read tunable config: tunable state in raft core is poisoned"))
+                    }
+                }
+            }
             _ => Err(anyhow!("the message not supported")),
         }
     }

--- a/lol-core/src/lib.rs
+++ b/lol-core/src/lib.rs
@@ -348,10 +348,10 @@ impl<A: RaftApp> RaftCore<A> {
                 let res = core_message::Rep::HealthCheck { ok: true };
                 Ok(core_message::Rep::serialize(&res))
             }
-            core_message::Req::TuneConfigInfo => {
+            core_message::Req::TunableConfigInfo => {
                 match self.tunable.try_read() {
                     Ok(tunable) => {
-                        let res = core_message::Rep::TuneConfigInfo {
+                        let res = core_message::Rep::TunableConfigInfo {
                             compaction_delay_sec: tunable.compaction_delay_sec,
                             compaction_interval_sec: tunable.compaction_interval_sec,
                         };

--- a/lol-core/src/server.rs
+++ b/lol-core/src/server.rs
@@ -60,15 +60,15 @@ pub struct Server<A: RaftApp> {
 #[tonic::async_trait]
 impl<A: RaftApp> Raft for Server<A> {
 
-    async fn tune_config(
+    async fn tunable_config(
         &self,
         request: tonic::Request<TunableConfigReq>,
     ) -> Result<tonic::Response<TunableConfigRep>, tonic::Status> {
         let req: TunableConfigReq = request.into_inner();
         match self.core.tunable.try_write() {
             Ok(mut tunable) => {
-                (*tunable).compaction_delay_sec = req.compaction_delay_sec;
-                (*tunable).compaction_interval_sec = req.compaction_interval_sec;
+                req.compaction_delay_sec.map(|value| (*tunable).compaction_delay_sec = value);
+                req.compaction_interval_sec.map(|value| (*tunable).compaction_interval_sec = value);
                 Ok(tonic::Response::new(proto_compiled::TunableConfigRep { }))
             },
             Err(poisoned_error) => {

--- a/lol-core/src/server.rs
+++ b/lol-core/src/server.rs
@@ -8,7 +8,7 @@ use proto_compiled::{
     raft_server::Raft, AddServerRep, AddServerReq, AppendEntryRep, AppendEntryReq, ApplyRep,
     ApplyReq, CommitRep, CommitReq, GetSnapshotReq, HeartbeatRep, HeartbeatReq, ProcessRep,
     ProcessReq, RemoveServerRep, RemoveServerReq, RequestVoteRep, RequestVoteReq, TimeoutNowRep,
-    TimeoutNowReq,
+    TimeoutNowReq, TunableConfigReq, TunableConfigRep
 };
 // This code is expecting stream in a form
 // Header (Entry Frame+)
@@ -59,6 +59,26 @@ pub struct Server<A: RaftApp> {
 }
 #[tonic::async_trait]
 impl<A: RaftApp> Raft for Server<A> {
+
+    async fn tune_config(
+        &self,
+        request: tonic::Request<TunableConfigReq>,
+    ) -> Result<tonic::Response<TunableConfigRep>, tonic::Status> {
+        let req: TunableConfigReq = request.into_inner();
+        match self.core.tunable.try_write() {
+            Ok(mut tunable) => {
+                (*tunable).compaction_delay_sec = req.compaction_delay_sec;
+                (*tunable).compaction_interval_sec = req.compaction_interval_sec;
+                Ok(tonic::Response::new(proto_compiled::TunableConfigRep { }))
+            },
+            Err(poisoned_error) => {
+                Err(tonic::Status::internal(
+                    format!("cannot update tunable configuration: state is poisoned({})", poisoned_error)
+                ))
+            }
+        }
+    }
+
     async fn request_apply(
         &self,
         request: tonic::Request<ApplyReq>,


### PR DESCRIPTION
# What this PR does

Add new message `TunableConfig` for grpc communication with server (TunableConfigReq & TunableConfigRep)
Add `tunable_config` rpc call to Service Raft
Add `TunableConfigInfo` to core_message:req and core_message:rep to be able to query TunableConfig from RaftCore
Add `tunable-config` to lol-admin to query `TunableConfigInfo`

# Rel

Fixes #57: Implement Tune message

