### PR TITLE
monitor: test: Kill threads on exit

### DIFF
--- a/lol-monitor/test.rb
+++ b/lol-monitor/test.rb
@@ -1,29 +1,34 @@
+N=3
 ND=[]
-(0...10).each { |i|
-    offset = 50+i
-    ND << "http://localhost:500#{offset}"
-}
-# FIXME:
-# kill the kvs-server processes after this script is done.
-ND.each { |nd|
-    Thread.fork {
-        `kvs-server #{nd}`
-    }
-}
+(0...N).each do |i|
+  j = 50+i
+  ND << "http://localhost:500#{j}"
+end
+
+pidlist = []
+
+ND.each do |nd|
+  pidlist << Process.spawn("kvs-server #{nd}")
+end
 sleep(5)
 
 MASTER=ND[0]
-(0...10).each { |i|
-    `lol-admin #{MASTER} add-server #{ND[i]}`
-    sleep(2)
-}
+(0...N).each do |i|
+  `lol-admin #{MASTER} add-server #{ND[i]}`
+  sleep(2)
+end
 
-5.times {
-    Thread.fork {
-        loop {
-            `kvs-client #{MASTER} set k v`
-        }
-    }
-}
+2.times do
+  pidlist << Process.fork do
+    loop do
+      `kvs-client #{MASTER} set k v`
+    end
+  end
+end
 
 system "cargo run --bin lol-monitor #{MASTER}"
+
+pidlist.each do |pid|
+  Process.detach(pid)
+  Process.kill(9, pid)
+end


### PR DESCRIPTION
Fix an issue that spawned processes are live after test program ends.