### PR TITLE
codecov: Use llvm docker image as the base

### DIFF
--- a/codecov/Dockerfile
+++ b/codecov/Dockerfile
@@ -1,14 +1,9 @@
-FROM 'ubuntu:21.04'
+FROM 'silkeh/clang:dev'
 
 WORKDIR '/lol_root/codecov'
 
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
-	llvm \
-	curl sudo less \
-	build-essential clang
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+	curl build-essential
 
 ARG USER
 ARG UID
@@ -18,6 +13,11 @@ RUN useradd -d /home/${USER} -m -s /bin/bash -u ${UID} -g ${GID} -G sudo ${USER}
 RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER ${USER}
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/home/${USER}/.cargo/bin:$PATH
+RUN echo $PATH
+
+ENV CARGO_TARGET_DIR=/tmp/cargo-target
 RUN rustup install nightly
 RUN rustup default nightly
 RUN rustup component add llvm-tools-preview

--- a/codecov/script/cov_report.sh
+++ b/codecov/script/cov_report.sh
@@ -1,8 +1,7 @@
-LOL_ROOT=..
-OUTPUT=/tmp/merged.profdata
+MERGED=/tmp/merged.profdata
 
-llvm-profdata-11 merge ${LOL_ROOT}/integration-tests/cov/*.profraw -o ${OUTPUT}
-llvm-cov-11 report ${LOL_ROOT}/target/debug/kvs-server \
+llvm-profdata merge ../integration-tests/cov/*.profraw -o ${MERGED}
+llvm-cov report /tmp/cargo-target/debug/kvs-server \
     -Xdemangler=rustfilt \
-    -instr-profile=${OUTPUT} \
+    -instr-profile=${MERGED} \
     --ignore-filename-regex="(.cargo|rustc)" 


### PR DESCRIPTION
This PR tries to fix codecov issue but actually it doesn't. But will be merged because it is apparently an improvement.

The codecov/Dockerfile now uses a LLVM image from https://github.com/silkeh/docker-clang since latest LLVM tools are required.