### PR TITLE
191 - Dockerfile for lol-admin; run.sh for KVS example

### DIFF
--- a/examples/kvs/run.sh
+++ b/examples/kvs/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# just a simple run script to start the servers and allow cleanup
+
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
+
+# start the nodes
+########################################################
+
+RUST_LOG=info cargo run --bin kvs-server http://localhost:3000 &
+RUST_LOG=info cargo run --bin kvs-server http://localhost:3001 &
+RUST_LOG=info cargo run --bin kvs-server http://localhost:3002 &
+
+# buffer for build times and boot times a bit
+########################################################
+
+sleep 30
+
+# cluster the nodes
+########################################################
+
+# bootstrap the first node to itself, add other nodes
+(cd ../../lol-admin/ && cargo run http://localhost:3000 add-server http://localhost:3000 && cargo run http://localhost:3000 add-server http://localhost:3001 && cargo run http://localhost:3000 add-server http://localhost:3002)
+
+wait

--- a/lol-admin/Dockerfile
+++ b/lol-admin/Dockerfile
@@ -1,0 +1,21 @@
+FROM rust:latest
+
+# needed for lol-core
+RUN rustup component add rustfmt
+
+# given the existing project structure, from lol-admin dir
+# you run from one dir up to capture lol-core dependency
+# docker build -t lol-admin -f Dockerfile ..
+
+# then we have access to whole project for lol-core dependency
+COPY ./ /lol
+# TODO: could parameterize this so it could target lol-monitor
+# though here we only want to build admin
+WORKDIR /lol/lol-admin
+
+RUN cargo build --release
+
+# the build goes back into the parent lol dir
+# when running, bind to the host so we can hit localhost too
+# docker run --network="host" lol-admin
+ENTRYPOINT ["../target/release/lol-admin"]

--- a/lol-admin/README.md
+++ b/lol-admin/README.md
@@ -25,3 +25,10 @@ SUBCOMMANDS:
     timeout-now
     tunable-config
 ```
+
+## Docker
+
+```
+docker build -t lol-admin -f Dockerfile ..
+docker run --network="host" lol-admin http://localhost:3000 cluster-info
+```


### PR DESCRIPTION
Hello, I was looking at [191](https://github.com/akiradeveloper/lol/issues/191) and attempted a basic `Dockerfile` for `lol-admin`. As I was learning, I also wrote a `run.sh` in KVS which somewhat mirrors the integration test flow. I can remove this if it is just clutter.