### PR TITLE
Add low-level API to hide the core paremeter

### DIFF
--- a/examples/kvs/src/kvs_client.rs
+++ b/examples/kvs/src/kvs_client.rs
@@ -45,7 +45,6 @@ async fn main() {
             let msg = Req::serialize(&msg);
             let res = conn
                 .request_apply(proto_compiled::ApplyReq {
-                    core: false,
                     message: msg,
                     mutation: false,
                 })
@@ -75,12 +74,9 @@ async fn main() {
                 value: value_rep,
             };
             let msg = Req::serialize(&msg);
-            conn.request_commit(proto_compiled::CommitReq {
-                core: false,
-                message: msg,
-            })
-            .await
-            .unwrap();
+            conn.request_commit(proto_compiled::CommitReq { message: msg })
+                .await
+                .unwrap();
             println!("OK");
         }
         Sub::List => {
@@ -88,7 +84,6 @@ async fn main() {
             let msg = Req::serialize(&msg);
             let res = conn
                 .request_apply(proto_compiled::ApplyReq {
-                    core: false,
                     message: msg,
                     mutation: false,
                 })

--- a/lol-core/proto/lol-core.proto
+++ b/lol-core/proto/lol-core.proto
@@ -4,15 +4,22 @@ package lol_core;
 
 message ApplyReq {
     bytes message = 1;
-    bool core = 2;
-    bool mutation = 3;
-}
-message ApplyRep {
-    bytes message = 1;
+    bool mutation = 2;
 }
 message CommitReq {
     bytes message = 1;
-    bool core = 2;
+}
+message LowLevelApplyReq {
+    bool core = 1;
+    bytes message = 2;
+    bool mutation = 3;
+}
+message LowLevelCommitReq {
+    bool core = 1;
+    bytes message = 2;
+}
+message ApplyRep {
+    bytes message = 1;
 }
 message CommitRep {}
 message Entry {
@@ -103,6 +110,8 @@ service Raft {
     rpc GetSnapshot (GetSnapshotReq) returns (stream GetSnapshotRep);
     rpc RequestApply (ApplyReq) returns (ApplyRep);
     rpc RequestCommit (CommitReq) returns (CommitRep);
+    rpc LowLevelRequestApply (LowLevelApplyReq) returns (ApplyRep);
+    rpc LowLevelRequestCommit (LowLevelCommitReq) returns (CommitRep);
     rpc SendHeartbeat (HeartbeatReq) returns (HeartbeatRep);
     rpc TimeoutNow (TimeoutNowReq) returns (TimeoutNowRep);
     rpc AddServer (AddServerReq) returns (AddServerRep);


### PR DESCRIPTION
Exhibiting the `core` parameter to the application developer isn't a preferred way of designing the API. This commit renames old API to low-level API and defines new API without core paramter.