### PR TITLE
Move SnapshotStream to crate root

### DIFF
--- a/lol-core/src/simple.rs
+++ b/lol-core/src/simple.rs
@@ -1,5 +1,5 @@
-use crate::snapshot::{BytesSnapshot, FileSnapshot, SnapshotStream};
-use crate::{Index, MakeSnapshot, RaftApp};
+use crate::snapshot::{BytesSnapshot, FileSnapshot};
+use crate::{Index, MakeSnapshot, RaftApp, SnapshotStream};
 use ::bytes::Bytes;
 use anyhow::Result;
 use async_trait::async_trait;

--- a/lol-core/src/snapshot/mod.rs
+++ b/lol-core/src/snapshot/mod.rs
@@ -10,10 +10,7 @@ use bytes::Bytes;
 use crate::proto_compiled::GetSnapshotRep;
 use futures::stream::Stream;
 
-/// The stream type that is used internally. it is considered as just a stream of bytes.
-/// The length of each bytes may vary.
-pub type SnapshotStream =
-    std::pin::Pin<Box<dyn futures::stream::Stream<Item = anyhow::Result<Bytes>> + Send>>;
+use crate::SnapshotStream;
 
 pub(crate) type SnapshotStreamOut = std::pin::Pin<
     Box<dyn futures::stream::Stream<Item = Result<GetSnapshotRep, tonic::Status>> + Send>,


### PR DESCRIPTION
Two reasons to move up the type to the crate level from the snapshot mod.

1. snapshot mod has only one member because all the others are hidden now.
2. `RaftApp` depends on `SnapshotStream`. `SnapshotStream` is an important concept in this library so it is reasonable to move it up to crate root.