### PR TITLE
Remove Entry from proto

### DIFF
--- a/lol-core/proto/lol-core.proto
+++ b/lol-core/proto/lol-core.proto
@@ -22,11 +22,6 @@ message ApplyRep {
     bytes message = 1;
 }
 message CommitRep {}
-message Entry {
-    uint64 term = 1;
-    uint64 index = 2;
-    bytes command = 3;
-}
 message AppendStreamHeader {
     string sender_id = 1;
     uint64 prev_log_term = 2;


### PR DESCRIPTION
This struct isn't used anymore since stream-version of the api was introduced.