### PR TITLE
Snapshot stream chunk should be encoded as Bytes

### DIFF
--- a/lol-core/build.rs
+++ b/lol-core/build.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     .compile(&["proto/lol-core.proto"], &["proto"])?;
 
     let mut config = prost_build::Config::new();
-    config.bytes(&[".lol_core.AppendStreamEntry.command"]);
+    config.bytes(&[".lol_core.AppendStreamEntry.command", ".lol_core.GetSnapshotRep.chunk"]);
     config.protoc_arg("--experimental_allow_proto3_optional");
     tonic_build::configure().compile_with_config(config, &["proto/lol-core.proto"], &["proto"])?;
 

--- a/lol-core/src/snapshot/mod.rs
+++ b/lol-core/src/snapshot/mod.rs
@@ -18,7 +18,7 @@ pub(crate) type SnapshotStreamOut = std::pin::Pin<
 
 pub(crate) fn into_out_stream(in_stream: SnapshotStream) -> SnapshotStreamOut {
     let out_stream = in_stream.map(|res| {
-        res.map(|x| GetSnapshotRep { chunk: x.to_vec() })
+        res.map(|x| GetSnapshotRep { chunk: x })
             .map_err(|_| tonic::Status::unknown("streaming error"))
     });
     Box::pin(out_stream)


### PR DESCRIPTION
As well as `AppendEntry` API, snapshot stream should be able to be decoded as a stream of `Bytes`.

The internal stream `SnapshotStream` has to be based on `Bytes` because of the `BytesCodec` used inside. Thus, if the out-going stream `GetSnapshotRep` is `Vec<u8>` there needs a conversion from `Bytes` to `Vec<u8>`. In theory, this could be zero-cost if the ref count is 1 however, it is not actually at the moment: The conversion `to_vec` at the moment needs a copy.

This change should remove the cost of the copy in snapshot streaming.