### PR TITLE
Fix: snapshot-queue: Immediately returns if the queue is pending.

### DIFF
--- a/lol-core/Cargo.toml
+++ b/lol-core/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["raft"]
 
 [dependencies]
 tokio = { version = "1.10", features = ["macros", "fs"] }
-tokio-util = { version = "0.6", features = ["codec", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "time"] }
 tokio-stream = "0.1"
 tonic = "0.6"
 http-serde = "1"

--- a/lol-core/src/snapshot/queue.rs
+++ b/lol-core/src/snapshot/queue.rs
@@ -40,7 +40,7 @@ impl SnapshotQueue {
             match futures::future::poll_immediate(fut).await {
                 // First `Some` means it is ready.
                 // Second `Some` means there is an entry in the queue.
-                Some(Some(Ok(expired))) => {
+                Some(Some(expired)) => {
                     let InsertEntry { e, tx } = expired.into_inner();
                     let snapshot_index = e.this_clock.index;
                     let ok = raft_core.log.insert_snapshot(e).await.is_ok();


### PR DESCRIPTION
Awaiting the queue in the stream waits for the next entry to expire
unless the queue is empty.
This is mutex held so the other process try to get the lock will wait
for the next entry to expire: Currently it is at worst 10s.